### PR TITLE
Fix to remove warning: Each child in a list should have a unique key …

### DIFF
--- a/mywebsite-react-apollo/src/components/ItemList.js
+++ b/mywebsite-react-apollo/src/components/ItemList.js
@@ -8,6 +8,7 @@ const ITEM_QUERY = gql`
 {
   getItems(filter: "Apple")
   {
+     id
      title
      description
      quantity


### PR DESCRIPTION
…prop.